### PR TITLE
Check fan off state

### DIFF
--- a/kauf-rgbs.yaml
+++ b/kauf-rgbs.yaml
@@ -113,7 +113,7 @@ esphome:
 external_components:
   - source:
       type: git
-      url: https://github.com/KaufHA/common
+      url: https://github.com/bkaufx/common
       # ref: v2022.09.03
     refresh: 0s
 

--- a/yaml-features/README.md
+++ b/yaml-features/README.md
@@ -110,7 +110,7 @@ The **mode_time** substitution defines the amount of time without a press that w
 
 **Fan Speed Percentages**
 
-The substitutions **speed_0_prcnt, speed_1_prcnt, speed_2_prcnt, and speed_3_prcnt** allow configuration of four different speed percentages for the fan.  By default, the speeds are 0, 33, 67, and 100.
+The substitutions **speed_0_prcnt, speed_1_prcnt, speed_2_prcnt, and speed_3_prcnt** allow configuration of four different speed percentages for the fan.  By default, the speeds are 0, 33, 67, and 100.  If **speed_0_prcnt** is not `'0'` (equivalent to "off"), behavior *might* be unexpected.
 
 **Fan Speed Colors**
 

--- a/yaml-features/hold-for-fan-mode.yaml
+++ b/yaml-features/hold-for-fan-mode.yaml
@@ -108,6 +108,10 @@ text_sensor:
     id: hass_fan_state
     name: HASS Fan State
     entity_id: $hass_fan_entity
+  - platform: homeassistant
+    id: hass_fan_speed
+    name: HASS Fan Speed
+    entity_id: $hass_fan_entity
     attribute: percentage
 
 
@@ -145,19 +149,26 @@ script:
                 call = id(small_light).turn_on();
 
                 // grab color based on speed
-                if (strcmp(id(hass_fan_state).state.c_str(),"$speed_1_prcnt") == 0) {
+                if (strcmp(id(hass_fan_state).state.c_str(),"off") == 0) {
+                  // if fan is off, speed "0" is assumed
+                  int used_colors2[3] = {$speed_0_color};
+                  red = used_colors2[0];
+                  green = used_colors2[1];
+                  blue = used_colors2[2];
+                }
+                else if (strcmp(id(hass_fan_speed).state.c_str(),"$speed_1_prcnt") == 0) {
                   int used_colors2[3] = {$speed_1_color};
                   red = used_colors2[0];
                   green = used_colors2[1];
                   blue = used_colors2[2];
                 }
-                else if (strcmp(id(hass_fan_state).state.c_str(),"$speed_2_prcnt") == 0) {
+                else if (strcmp(id(hass_fan_speed).state.c_str(),"$speed_2_prcnt") == 0) {
                   int used_colors2[3] = {$speed_2_color};
                   red = used_colors2[0];
                   green = used_colors2[1];
                   blue = used_colors2[2];
                 }
-                else if (strcmp(id(hass_fan_state).state.c_str(),"$speed_3_prcnt") == 0) {
+                else if (strcmp(id(hass_fan_speed).state.c_str(),"$speed_3_prcnt") == 0) {
                   int used_colors2[3] = {$speed_3_color};
                   red = used_colors2[0];
                   green = used_colors2[1];
@@ -186,21 +197,29 @@ script:
                 int red, green, blue, fan_speed;
 
                 // set speed and grab color based on current speed
-                if (strcmp(id(hass_fan_state).state.c_str(),"$speed_1_prcnt") == 0) {
+                if (strcmp(id(hass_fan_state).state.c_str(),"off") == 0) {
+                  // if fan is off, speed "0" is assumed
+                  int used_colors2[3] = {$speed_1_color};
+                  red = used_colors2[0];
+                  green = used_colors2[1];
+                  blue = used_colors2[2];
+                  fan_speed = $speed_1_prcnt;
+                }
+                else if (strcmp(id(hass_fan_speed).state.c_str(),"$speed_1_prcnt") == 0) {
                   int used_colors2[3] = {$speed_2_color};
                   red = used_colors2[0];
                   green = used_colors2[1];
                   blue = used_colors2[2];
                   fan_speed = $speed_2_prcnt;
                 }
-                else if (strcmp(id(hass_fan_state).state.c_str(),"$speed_2_prcnt") == 0) {
+                else if (strcmp(id(hass_fan_speed).state.c_str(),"$speed_2_prcnt") == 0) {
                   int used_colors2[3] = {$speed_3_color};
                   red = used_colors2[0];
                   green = used_colors2[1];
                   blue = used_colors2[2];
                   fan_speed = $speed_3_prcnt;
                 }
-                else if (strcmp(id(hass_fan_state).state.c_str(),"$speed_3_prcnt") == 0) {
+                else if (strcmp(id(hass_fan_speed).state.c_str(),"$speed_3_prcnt") == 0) {
                   int used_colors2[3] = {$speed_0_color};
                   red = used_colors2[0];
                   green = used_colors2[1];


### PR DESCRIPTION
My fan controller (Martin Jerry - Tasmota pre-installed) wasn't compatible with your logic.  Turns out, it keeps its last speed setting when turned off, then turns on at the last speed.

This change checks the on/off state, as well as the speed percentage, to determine the state of the fan.

I believe this should continue to work with fans that worked before.  If not, it would be easy to add a boolean option to enable the new logic.